### PR TITLE
Retirer la phrase « NAC supplémentaire : sur devis »

### DIFF
--- a/src/components/services/ServicesSection.astro
+++ b/src/components/services/ServicesSection.astro
@@ -92,8 +92,7 @@ const { id, ...props } = Astro.props
           <p>
             <AsteriskIcon class="mr-1 inline w-5" />
             <strong>Au-delà de 2 chats, d’1 chien ou d’1 NAC :</strong>
-            {siteConfig.pricing.visit.additionalAnimal}€ par animal supplémentaire par visite. NAC
-            supplémentaire : sur devis.
+            {siteConfig.pricing.visit.additionalAnimal}€ par animal supplémentaire par visite.
           </p>
 
           <VisitPricing />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexte

Suppression de la phrase « NAC supplémentaire : sur devis. » dans la section services (visites à domicile), conformément à la demande.

## Modifications

- Dans `ServicesSection.astro`, le paragraphe sur les animaux supplémentaires se termine désormais après le tarif par animal supplémentaire par visite, sans mention distincte pour le NAC.

## Vérifications

- `pnpm lint` : OK
- `pnpm test run` : OK (11 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-870a8b4d-2771-4993-9494-3a5a4fbd8b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-870a8b4d-2771-4993-9494-3a5a4fbd8b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

